### PR TITLE
Adding a `static`-flag to the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ option | values | default
 `jsx.extension` | any file extension with leading `.` | `".jsx"`
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
 `beautify` | `true`: beautify markup before outputting (note, this can affect rendering due to additional whitespace) | `false`
+`static` | `false`: Leaves the references to the Virtual DOM in the markup for dynamic use of the component on the client side. | `true`
 
 The defaults are sane, but just in case you want to change something, here's how it would look:
 

--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ var DEFAULT_OPTIONS = {
     harmony: false
   },
   doctype: '<!DOCTYPE html>',
-  beautify: false
+  beautify: false,
+  static: true
 };
 
 module.exports = function createEngine(engineOptions) {
-  engineOptions = _merge(DEFAULT_OPTIONS, engineOptions);
+  engineOptions = _merge({}, DEFAULT_OPTIONS, engineOptions);
 
   // Don't install the require until the engine is created. This lets us leave
   // the option of using harmony features up to the consumer.
@@ -40,10 +41,11 @@ module.exports = function createEngine(engineOptions) {
     }
 
     return function _compile(context) {
-      var markup = doctype;
+      var markup = doctype,
+          render = engineOptions.static ? 'renderToStaticMarkup' : 'renderToString';
 
       try {
-        markup += React.renderToStaticMarkup(component(context));
+        markup += React[render](component(context));
       } catch (e) {
         throw e;
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "hapi": "^7.5.2",
+    "jsdom": "^3.1.0",
     "jshint": "^2.5.10",
     "mocha": "^2.0.1",
     "react": "^0.12.0"

--- a/test.js
+++ b/test.js
@@ -2,42 +2,92 @@
 
 var assert = require('assert');
 var path = require('path');
+var jsdom = require('jsdom');
 var hapi = require('hapi');
-var engine = require('./')();
+var hapiReact = require('./');
 
 describe('hapi-react', function() {
-  var server;
+  var engine;
 
-  before(function() {
-    server = new hapi.Server(0);
+  describe('standard', function() {
+    var server;
 
-    server.views({
-      defaultExtension: 'jsx',
-      path: path.join(__dirname, 'fixtures'),
-      engines: {
-        jsx: engine,
-        js: engine
-      }
+    before(function() {
+      engine = hapiReact({
+        static: false
+      });
+      server = new hapi.Server(0);
+
+      server.views({
+        defaultExtension: 'jsx',
+        path: path.join(__dirname, 'fixtures'),
+        engines: {
+          jsx: engine,
+          js: engine
+        }
+      });
     });
-  });
 
-  it('renders a .jsx file', function(done) {
-    // Verify that it renders once
-    server.render('hi', { message: 'hi' }, function(err, rendered) {
-      server.render('hi', { message: 'hi' }, function(err, _rendered) {
-        var expected = '<!DOCTYPE html><html><head></head><body>hi</body></html>';
-        assert.equal(rendered, expected);
-        assert.equal(_rendered, expected);
-        done();
+    it('renders a .jsx file', function(done) {
+      server.render('hi', { message: 'hi' }, function(err, rendered) {
+        jsdom.env(rendered, function(err, window) {
+          assert.ok(window.document.documentElement.getAttribute('data-reactid'));
+          assert.ok(window.document.documentElement.getAttribute('data-react-checksum'));
+          assert.ok(window.document.body.getAttribute('data-reactid'));
+          assert.equal(window.document.body.textContent, 'hi');
+          done();
+        });
+      });
+    });
+
+    it('renders a .js file', function(done) {
+      server.render('bye.js', { message: 'bye' }, function(err, rendered) {
+        jsdom.env(rendered, function(err, window) {
+          assert.ok(window.document.documentElement.getAttribute('data-reactid'));
+          assert.ok(window.document.documentElement.getAttribute('data-react-checksum'));
+          assert.ok(window.document.body.getAttribute('data-reactid'));
+          assert.equal(window.document.body.textContent, 'bye');
+          done();
+        });
       });
     });
   });
 
-  it('renders a .js file', function(done) {
-    server.render('bye.js', { message: 'bye' }, function(err, rendered) {
-      var expected = '<!DOCTYPE html><html><head></head><body>bye</body></html>';
-      assert.equal(rendered, expected);
-      done();
+  describe('static', function() {
+    var server;
+
+    before(function() {
+      engine = hapiReact();
+      server = new hapi.Server(0);
+
+      server.views({
+        defaultExtension: 'jsx',
+        path: path.join(__dirname, 'fixtures'),
+        engines: {
+          jsx: engine,
+          js: engine
+        }
+      });
+    });
+
+    it('statically renders a .jsx file', function(done) {
+      // Verify that it renders once
+      server.render('hi', { message: 'hi' }, function(err, rendered) {
+        server.render('hi', { message: 'hi' }, function(err, _rendered) {
+          var expected = '<!DOCTYPE html><html><head></head><body>hi</body></html>';
+          assert.equal(rendered, expected);
+          assert.equal(_rendered, expected);
+          done();
+        });
+      });
+    });
+
+    it('statically renders a .js file', function(done) {
+      server.render('bye.js', { message: 'bye' }, function(err, rendered) {
+        var expected = '<!DOCTYPE html><html><head></head><body>bye</body></html>';
+        assert.equal(rendered, expected);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
In order to re-use components in the browser one needs the references to the Virtual DOM. So I added a `static`-flag to the options and have the render-type depending on it.