### PR TITLE
update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ Under the hood, [Babel](http://babeljs.io/) is used to compile your views into E
 Your views should be node modules that export a React component. Let's assume you have this file in `views/index.jsx`:
 
 ```js
-/** @jsx React.DOM */
-
 var React = require('react');
 var HelloMessage = React.createClass({
   render: function() {


### PR DESCRIPTION
/** @jsx React.DOM */ causes an error on startup:
SyntaxError: C:/Users/code/hapi-react/views/index.jsx: Line 1: The @jsx React.DOM pragma has been deprecated as of React 0.12

Node Version used: v5.5.0
OS: Windows 8.1

This pullrequest removes the @jsx: React.DOM line.